### PR TITLE
Added leo-profanity npm library for profanity filtering on review text

### DIFF
--- a/models/Review.js
+++ b/models/Review.js
@@ -1,5 +1,6 @@
 const { Model, DataTypes } = require("sequelize");
 const sequelize = require("../config/connection");
+const filter = require("leo-profanity");
 
 class Review extends Model {}
 
@@ -60,6 +61,16 @@ Review.init(
     },
   },
   {
+    hooks: {
+      beforeCreate: (reviewData) => {
+        reviewData.review = filter.clean(reviewData.review);
+        return reviewData;
+      },
+      beforeUpdate: (reviewData) => {
+        reviewData.review = filter.clean(reviewData.review);
+        return reviewData;
+      },
+    },
     sequelize,
     timestamps: true,
     freezeTableName: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,9 @@
         "express-handlebars": "^5.2.0",
         "express-session": "^1.17.1",
         "handlebars": "^4.7.3",
+        "leo-profanity": "^1.5.0",
         "mysql2": "^2.2.5",
         "sequelize": "^6.3.5",
-        "toastify": "^2.0.1",
         "validator": "^13.7.0"
       },
       "devDependencies": {
@@ -1006,6 +1006,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/french-badwords-list": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/french-badwords-list/-/french-badwords-list-1.0.5.tgz",
+      "integrity": "sha512-MZ4tpLH+GNlFEx62RLZAttE/ZvmYf42M3MFwh9QK/l4TV6WgZWy1bx4xI3z9mjuLh5GWQQ5jLOx8BFUAwt99tw==",
+      "optional": true
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -1760,6 +1766,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/leo-profanity": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/leo-profanity/-/leo-profanity-1.5.0.tgz",
+      "integrity": "sha512-4Xa4dF/YiMWQNy9Y36L+fZiPPM4fXrYJUkM8Pm4sxDB5TLHKzuwMRzggxJiYn0xAKVvq0ra+77PrtSbNA2LY4g==",
+      "optionalDependencies": {
+        "french-badwords-list": "^1.0.5",
+        "russian-bad-words": "^0.5.0"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -2489,6 +2504,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/russian-bad-words": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/russian-bad-words/-/russian-bad-words-0.5.0.tgz",
+      "integrity": "sha512-euNvEYki6iYYpkNbeudW+lEMMYGEmN7EBwVF8ezlbv0bZoQpVYB7W10cCeUIGV7Ed50sJynLQ0c559q5iI0ejQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2838,11 +2862,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/toastify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/toastify/-/toastify-2.0.1.tgz",
-      "integrity": "sha512-Me/O93yAlwiHYwqX0su60Wv+X9ngzIT6nBLbNAFED095gMSjCBYKdu+faBxV6SE8CiQjUTBLrz8LwoXMtGz+yw=="
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -3975,6 +3994,12 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
     },
+    "french-badwords-list": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/french-badwords-list/-/french-badwords-list-1.0.5.tgz",
+      "integrity": "sha512-MZ4tpLH+GNlFEx62RLZAttE/ZvmYf42M3MFwh9QK/l4TV6WgZWy1bx4xI3z9mjuLh5GWQQ5jLOx8BFUAwt99tw==",
+      "optional": true
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -4502,6 +4527,15 @@
       "dev": true,
       "requires": {
         "package-json": "^6.3.0"
+      }
+    },
+    "leo-profanity": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/leo-profanity/-/leo-profanity-1.5.0.tgz",
+      "integrity": "sha512-4Xa4dF/YiMWQNy9Y36L+fZiPPM4fXrYJUkM8Pm4sxDB5TLHKzuwMRzggxJiYn0xAKVvq0ra+77PrtSbNA2LY4g==",
+      "requires": {
+        "french-badwords-list": "^1.0.5",
+        "russian-bad-words": "^0.5.0"
       }
     },
     "lodash": {
@@ -5040,6 +5074,12 @@
         "glob": "^7.1.3"
       }
     },
+    "russian-bad-words": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/russian-bad-words/-/russian-bad-words-0.5.0.tgz",
+      "integrity": "sha512-euNvEYki6iYYpkNbeudW+lEMMYGEmN7EBwVF8ezlbv0bZoQpVYB7W10cCeUIGV7Ed50sJynLQ0c559q5iI0ejQ==",
+      "optional": true
+    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -5286,11 +5326,6 @@
       "requires": {
         "is-number": "^7.0.0"
       }
-    },
-    "toastify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/toastify/-/toastify-2.0.1.tgz",
-      "integrity": "sha512-Me/O93yAlwiHYwqX0su60Wv+X9ngzIT6nBLbNAFED095gMSjCBYKdu+faBxV6SE8CiQjUTBLrz8LwoXMtGz+yw=="
     },
     "toidentifier": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "express-handlebars": "^5.2.0",
     "express-session": "^1.17.1",
     "handlebars": "^4.7.3",
+    "leo-profanity": "^1.5.0",
     "mysql2": "^2.2.5",
     "sequelize": "^6.3.5",
     "validator": "^13.7.0"


### PR DESCRIPTION
Adds the leo-profanity library, so you'll have to run `npm i` to get it pulled down to review.

I added it directly into the Review model as a hook on the create and update. See screenshots for it working on my machine
<img width="906" alt="Screen Shot 2022-02-24 at 9 33 37 PM" src="https://user-images.githubusercontent.com/16024741/155660231-0a40a218-441b-4fb0-91e5-62c075501f48.png">
<img width="737" alt="Screen Shot 2022-02-24 at 9 33 04 PM" src="https://user-images.githubusercontent.com/16024741/155660243-abf6b74a-34ce-4efa-a714-6070289ecf6f.png">
.