### PR TITLE
tutor link fix & footer styling fix

### DIFF
--- a/views/homepage.handlebars
+++ b/views/homepage.handlebars
@@ -11,7 +11,7 @@
         <h5 class="dashFacts card-text p-2">
           Wisdom in a cup. </h5>
         
-          <a href="/tutor" id="searchButton" class="submitBtn btn btn-md btn-dark">
+          <a href="/tutorportal" id="searchButton" class="submitBtn btn btn-md btn-dark">
             <i
               class="bi bi-search text-center"
               alt="search-image"
@@ -62,7 +62,7 @@
 
 
 </section>
-<br><br>
+<br><br><br>
  <script src="/js/homepage.js"></script>
 
 

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -171,7 +171,7 @@
     {{/if}}
     {{! FOOTER }}
       <footer
-        id="footer" class="py-3 d-flex justify-content-between align-items-center vw-100"
+        id="footer" class="py-3 d-flex justify-content-between align-items-center"
       >
         <div id="footer-co" class="justify-content-start flex-start align-items-center ps-2">
           <p class="my-1">&copy;  <a class="text-light" href="/collab">Collabrewation</a> </p>


### PR DESCRIPTION
The tutor link on the homepage had /tutors but the actual path is /tutorportal - updated homepage so it links appropriately. 

Added another <br> tag at bottom of homepage handelbars so the footer sticks to the bottom as expected